### PR TITLE
Correction to the example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Example
 
     import github.com/couchbase/moss
 
-    c, err := moss.NewCollection(CollectionOptions{})
+    c, err := moss.NewCollection(moss.CollectionOptions{})
     defer c.Close()
 
-    batch, c := c.NewBatch(0, 0)
+    batch, err := c.NewBatch(0, 0)
     defer batch.Close()
 
     batch.Set([]byte("car-0"), []byte("tesla"))


### PR DESCRIPTION
The `CollectionOptions{}` needed prefixing with `moss.` and `c.NewBatch()` returns a `Batch` and an `error` therefore can't re-assign to `c` (of type `Collection`).
