### PR TITLE
avoid deadlock by starting collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Example
     import github.com/couchbase/moss
 
     c, err := moss.NewCollection(moss.CollectionOptions{})
+    c.Start()
     defer c.Close()
 
     batch, err := c.NewBatch(0, 0)


### PR DESCRIPTION
When running the Readme's example, you immediately run into an error since Start() hasn't been 
called on the collection.
This will help getting the first example running without having to look around 